### PR TITLE
Update AudioTool.js

### DIFF
--- a/tools/AudioTool.js
+++ b/tools/AudioTool.js
@@ -6,8 +6,8 @@ var AudioTool = function(mp3) {
   // MIC stuff
   this.stream = null;
   this.analyserNode = null;
-  this.data = null;
-  this.dataW = null;
+  this.data = [];
+  this.dataWave = [];
   this.size = 2048;
   this.counter = 0;
   this.setup();


### PR DESCRIPTION
this.dataWave n'était pas correctement initialisé dans le constructeur.
Je propose également d'initialiser this.dataWave et this.data avec des tableaux vides, dans le cas notamment où on veut accéder aux données du micro dans un draw (avec une boucle) mais que l'utilisateur n'a pas encore accepté, ce qui en l'état mêne à une erreur.